### PR TITLE
Added memoize-defmemo macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,23 @@ See the header in the source file for details. It's very easy to use:
 
 (memoize 'my-function)
 ```
+
+You can also use ```memoize-defmemo``` to create a new memoized
+function:
+
+```cl
+(require 'memoize)
+
+(memoize-defmemo my-expensive-function (x)
+   (if (zerop n)
+       1
+     (* n (my-expensive-function (1- n)))))
+```
+
+You may want to ```defalias``` ```memoize-defmemo``` to ```defmemo```:
+
+```cl
+(require 'memoize)
+
+(defalias 'defmemo 'memoize-defmemo)
+```

--- a/memoize.el
+++ b/memoize.el
@@ -49,6 +49,16 @@ install the memoized function over the original function."
             value
           (puthash args (apply func args) table))))))
 
+(defmacro memoize-defmemo (name arglist &optional docstring &rest body)
+  "Create a memoize'd function. NAME, ARGLIST, DOCSTRING and BODY
+have the same meaning as in `defun'."
+  (declare (indent defun))
+  `(progn
+     (defun ,name ,arglist
+       ,docstring
+       ,@body)
+     (memoize (quote ,name))))
+
 (provide 'memoize)
 
 ;;; memoize.el ends here


### PR DESCRIPTION
Added a macro called `memoize-defmacro` that automatically creates a new function and memoizes it.

Example of usage:

``` cl

(memoize-defmemo whiten (key)
  "Perform key whitening with the md5 hash function."
  (dotimes (i 1000000 key)
    (setq key (md5 key))))
```

Result:

``` cl
(measure-time (whiten "password")) ; => 3.3089375495910645 s
(measure-time (whiten "password")) ; => 1.2159347534179688e-05 s
```
