### PR TITLE
Stop memory leaks by having expiring memoization.

### DIFF
--- a/memoize-test.el
+++ b/memoize-test.el
@@ -1,0 +1,38 @@
+;;; Tests for memoize.el -*- lexical-binding: t; -*-
+
+(defvar numcalls 0)
+
+(ert-deftest memoize ()
+  ;; Have to defun each time since we don't want to keep re-memoizing
+  ;; the same function.
+  (defun testfunc (a)
+    (incf numcalls))
+  (setq numcalls 0)
+  (let ((run-at-time-timeout)
+        (run-at-time-func)
+        (timer-canceled))
+    (flet ((run-at-time (timeout repeat func)
+                        (setq run-at-time-timeout timeout)
+                        (should (null repeat))
+                        (setq run-at-time-func func))
+           (cancel-timer (timer)
+                         (setq timer-canceled t)))
+      (memoize #'testfunc "10 seconds")
+      (should (eq 0 numcalls))
+      (testfunc 1)
+      (should run-at-time-func)
+      (should (eq 1 numcalls))
+      ;; Timer should be called now
+      (should (equal "10 seconds" run-at-time-timeout))
+      (testfunc 1)
+      ;; This should be cached
+      (should (eq 1 numcalls))
+      (funcall run-at-time-func)
+      ;; Now the cache should be gone
+      (testfunc 1)
+      (message "Finished running testfunc")
+      (should (eq 2 numcalls))
+      ;; Another arg is another call
+      (testfunc 2)
+      (should (eq 3 numcalls)))))
+

--- a/memoize.el
+++ b/memoize.el
@@ -33,6 +33,13 @@
 ;; There's no way to memoize nil returns, but why would your expensive
 ;; functions do all that work just to return nil? :-)
 
+;; Memoization takes up memory, which should be freed at some point.
+;; Because of this, all memoization has a timeout from when the last
+;; access was. The default timeout is set by
+;; `memoize-default-timeout'.  It can be overriden by using the
+;; `memoize' function, but the `defmemoize' macro will always just use
+;; the default timeout.
+
 ;; If you wait to byte-compile the function until *after* it is
 ;; memoized then the function and memoization wrapper both get
 ;; compiled at once, so there's no special reason to do them
@@ -43,26 +50,48 @@
 
 (eval-when-compile (require 'cl))
 
-(defun memoize (func)
+(defvar memoize-default-timeout "2 hours"
+  "The amount of time after which to remove a memoization.
+This represents the time after last use of the memoization after
+which the value is expired. Setting this to nil means to never
+expire, which will cause a memory leak, but may be acceptable for
+very careful uses.")
+
+(defun memoize (func &optional timeout)
   "Memoize the given function. If argument is a symbol then
-install the memoized function over the original function."
+install the memoized function over the original function. The
+TIMEOUT value, a timeout string as used by `run-at-time' will
+determine when the value expires, and will apply after the last
+access (unless another access happens)."
   (typecase func
     (symbol
      (put func 'function-documentation
           (concat (documentation func) " (memoized)"))
-     (fset func (memoize--wrap (symbol-function func)))
+     (fset func (memoize--wrap (symbol-function func) timeout))
      func)
-    (function (memoize--wrap func))))
+    (function (memoize--wrap func timeout))))
 
 ;; ID: 83bae208-da65-3e26-2ecb-4941fb310848
-(defun memoize--wrap (func)
-  "Return the memoized version of FUNC."
-  (let ((table (make-hash-table :test 'equal)))
+(defun memoize--wrap (func timeout)
+  "Return the memoized version of FUNC.
+TIMEOUT specifies how long the values last from last access. A
+nil timeout will cause the values to never expire, which will
+cause a memory leak as memoize is use, so use the nil value with
+care."
+  (let ((table (make-hash-table :test 'equal))
+        (timeouts (make-hash-table :test 'equal)))
     (lambda (&rest args)
       (let ((value (gethash args table)))
-        (if value
-            value
-          (puthash args (apply func args) table))))))
+        (unwind-protect
+            (or value (puthash args (apply func args) table))
+          (let ((existing-timer (gethash args timeouts))
+                (timeout-to-use (or timeout memoize-default-timeout)))
+            (when existing-timer
+              (cancel-timer existing-timer))
+            (when timeout-to-use
+              (puthash args (run-at-time timeout-to-use nil
+                                         (lambda ()
+                                           (remhash args table))) timeouts))))))))
 
 (defmacro defmemoize (name arglist &rest body)
   "Create a memoize'd function. NAME, ARGLIST, DOCSTRING and BODY


### PR DESCRIPTION
The memoization values each have an associated timer, which will
expire it as a certain time since the last update.
