### PR TITLE
Add support for memoizing nil

### DIFF
--- a/memoize-test.el
+++ b/memoize-test.el
@@ -54,3 +54,32 @@
       (funcall f 0 0)
       (should (eq 3 numcalls)))))
 
+(ert-deftest memoize-nil ()
+  (let ((f (memoize (lambda (arg1 arg2)
+                      (incf numcalls)
+                      (if (= arg1 99) nil (+ arg1 arg2))))))
+    (setq numcalls 0)
+    (funcall f 99 1)
+    (should (eq nil (funcall f 99 1)))
+    (should (eq 1 numcalls))
+    (funcall f 98 2)
+    (should (eq 100 (funcall f 98 2)))
+    (should (eq 2 numcalls))))
+
+(ert-deftest memoize-nil-by-buffer-contents ()
+  (let ((f (memoize-by-buffer-contents--wrap
+            (lambda (arg1 arg2)
+              (incf numcalls)
+              (if (= arg1 99) nil (+ arg1 arg2))))))
+    (setq numcalls 0)
+    (with-temp-buffer
+      (funcall f 99 1)
+      (should (eq nil (funcall f 99 1)))
+      (should (eq 1 numcalls))
+      (funcall f 98 2)
+      (should (eq 100 (funcall f 98 2)))
+      (should (eq 2 numcalls))
+      (insert "hello world")
+      (funcall f 98 2)
+      (should (eq 3 numcalls)))))
+


### PR DESCRIPTION
> ;; There's no way to memoize nil returns, but why would your expensive
> ;; functions do all that work just to return nil? :-)

I had an example of an expensive function returning `nil`: http://emacs.stackexchange.com/a/19551/5296 (although it additionally needs memoizing only some arguments) and it's not so hard to memoize it, so why not?