### PR TITLE
Add: memoize-restore to de-memoize functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,11 @@ Some functions are run over buffer contents, and need to be cached
 only so long as the buffer contents do not change. For these
 use-cases, we have the function `memoize-by-buffer-contents` as well
 as the `defmemoize-by-buffer-contents` macro.
+
+To restore the original definition of a memoized function symbol (not
+a lambda or closure), use `memoize-restore`:
+
+```cl
+(memoize 'my-function)
+(memoize-restore 'my-function)
+```

--- a/memoize.el
+++ b/memoize.el
@@ -67,11 +67,26 @@ will apply after the last access (unless another access
 happens)."
   (cl-typecase func
     (symbol
+     (when (get func :memoize-original-function)
+       (user-error "%s is already memoized" func))
+     (put func :memoize-original-documentation (documentation func))
      (put func 'function-documentation
           (concat (documentation func) " (memoized)"))
+     (put func :memoize-original-function (symbol-function func))
      (fset func (memoize--wrap (symbol-function func) timeout))
      func)
     (function (memoize--wrap func timeout))))
+
+(defun memoize-restore (func)
+  "Restore the original, non-memoized definition of FUNC.
+FUNC should be a symbol which has been memoized with `memoize'."
+  (unless (get func :memoize-original-function)
+    (user-error "%s is not memoized" func))
+  (fset func (get func :memoize-original-function))
+  (put func :memoize-original-function nil)
+  (put func 'function-documentation
+       (get func :memoize-original-documentation))
+  (put func :memoize-original-documentation nil))
 
 (defun memoize--wrap (func timeout)
   "Return the memoized version of FUNC.


### PR DESCRIPTION
Also, raise an error if the user attempts to memoize an already-memoized function, which would cause the original function definition to be lost.

Closes #7.