### PR TITLE
Indicate some information for `defmemoize`.

### DIFF
--- a/memoize.el
+++ b/memoize.el
@@ -113,7 +113,7 @@ care."
 (defmacro defmemoize (name arglist &rest body)
   "Create a memoize'd function. NAME, ARGLIST, DOCSTRING and BODY
 have the same meaning as in `defun'."
-  (declare (indent defun))
+  (declare (indent defun) (doc-string 3))
   `(progn
      (defun ,name ,arglist
        ,@body)

--- a/memoize.el
+++ b/memoize.el
@@ -113,7 +113,7 @@ care."
 (defmacro defmemoize (name arglist &rest body)
   "Create a memoize'd function. NAME, ARGLIST, DOCSTRING and BODY
 have the same meaning as in `defun'."
-  (declare (indent defun) (doc-string 3))
+  (declare (indent defun) (doc-string 3) (debug defun))
   `(progn
      (defun ,name ,arglist
        ,@body)


### PR DESCRIPTION
So the font-lock of emacs-lisp-mode can highlight docstring correctly.